### PR TITLE
Adding basic unit tests for wazp.utils.

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         # Run all supported Python versions on linux (plus one development unsupported)
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11"]
         os: [ubuntu-latest]
         # Include one windows and macos run
         include:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [{name = "Sofia Miñano", email= "s.minano@ucl.ac.uk"},
            {name = "Adam Tyson", email= "code@adamltyson.com"}]
 description = "Wasp Animal-tracking Zoo project with Pose estimation"
 readme = "README.md"
-requires-python = ">=3.8.0"
+requires-python = ">=3.9.0"
 dynamic = ["version"]
 
 license = {text = "BSD-3-Clause"}
@@ -17,7 +17,6 @@ classifiers = [
     "Development Status :: 2 - Pre-Alpha",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Operating System :: OS Independent",
@@ -68,7 +67,7 @@ exclude = ["tests*"]
 addopts = "--cov=wazp"
 
 [tool.black]
-target-version = ['py38', 'py39', 'py310']
+target-version = ['py39', 'py310']
 skip-string-normalization = false
 line-length = 79
 exclude = '''

--- a/tests/test_unit/test_utils.py
+++ b/tests/test_unit/test_utils.py
@@ -14,18 +14,22 @@ def get_sample_project_metadata_fields() -> dict:
     return metadata_fields
 
 
-def test_df_from_metadata_yaml_sample_project_metadata() -> None:
+def test_columns_names_and_nrows_in_df_from_metadata() -> None:
     """Normal operation: test we can read the sample project metadata."""
-    fields = get_sample_project_metadata_fields()
-    testme = df_from_metadata_yaml_files("sample_project/videos", fields)
+    metadata_fields = get_sample_project_metadata_fields()
+    df_output = df_from_metadata_yaml_files(
+        "sample_project/videos", metadata_fields
+    )
 
-    expected = set(fields)
-    actual = set(testme.columns)
-    diff = expected.symmetric_difference(actual)
-    assert expected == actual, f"Metadata fields -> df problem with: {diff}"
+    fields_from_yaml = set(metadata_fields)
+    df_columns = set(df_output.columns)
+    diff = fields_from_yaml.symmetric_difference(df_columns)
+    assert (
+        fields_from_yaml == df_columns
+    ), f"Metadata fields and df columns differ in the following fields: {diff}"
 
     nfiles = len(glob.glob("sample_project/videos/*.yaml"))
-    nrows, _ = testme.shape
+    nrows, _ = df_output.shape
     assert nrows == nfiles, "Number of rows in df != number of yaml files."
 
 
@@ -34,11 +38,13 @@ def test_df_from_metadata_yaml_no_metadata() -> None:
     Test with no metadata files (expect just to create an empty dataframe with
     metadata_fields column headers).
     """
-    fields = get_sample_project_metadata_fields()
+    metadata_fields = get_sample_project_metadata_fields()
     with tempfile.TemporaryDirectory() as empty_existing_directory:
-        testme = df_from_metadata_yaml_files(empty_existing_directory, fields)
+        df_output = df_from_metadata_yaml_files(
+            empty_existing_directory, metadata_fields
+        )
 
-    assert testme.shape == (1, len(fields))
+    assert df_output.shape == (1, len(metadata_fields))
 
 
 def test_df_from_metadata_garbage() -> None:
@@ -47,5 +53,7 @@ def test_df_from_metadata_garbage() -> None:
         df_from_metadata_yaml_files("DIRECTORY_DOESNT_EXIST", dict())
 
     with tempfile.TemporaryDirectory() as empty_existing_directory:
-        testme = df_from_metadata_yaml_files(empty_existing_directory, dict())
-    assert testme.empty, "There shouldn't be any data in the df."
+        df_output = df_from_metadata_yaml_files(
+            empty_existing_directory, dict()
+        )
+    assert df_output.empty, "There shouldn't be any data in the df."

--- a/tests/test_unit/test_utils.py
+++ b/tests/test_unit/test_utils.py
@@ -1,0 +1,51 @@
+import glob
+import tempfile
+
+import pytest
+import yaml
+
+from wazp.utils import df_from_metadata_yaml_files
+
+
+def get_sample_project_metadata_fields() -> dict:
+    """Get the metadata dictionary from the sample project for testing."""
+    with open("sample_project/metadata_fields.yaml") as fi:
+        metadata_fields = yaml.safe_load(fi)
+    return metadata_fields
+
+
+def test_df_from_metadata_yaml_sample_project_metadata() -> None:
+    """Normal operation: test we can read the sample project metadata."""
+    fields = get_sample_project_metadata_fields()
+    testme = df_from_metadata_yaml_files("sample_project/videos", fields)
+
+    expected = set(fields)
+    actual = set(testme.columns)
+    diff = expected.symmetric_difference(actual)
+    assert expected == actual, f"Metadata fields -> df problem with: {diff}"
+
+    nfiles = len(glob.glob("sample_project/videos/*.yaml"))
+    nrows, _ = testme.shape
+    assert nrows == nfiles, "Number of rows in df != number of yaml files."
+
+
+def test_df_from_metadata_yaml_no_metadata() -> None:
+    """
+    Test with no metadata files (expect just to create an empty dataframe with
+    metadata_fields column headers).
+    """
+    fields = get_sample_project_metadata_fields()
+    with tempfile.TemporaryDirectory() as empty_existing_directory:
+        testme = df_from_metadata_yaml_files(empty_existing_directory, fields)
+
+    assert testme.shape == (1, len(fields))
+
+
+def test_df_from_metadata_garbage() -> None:
+    """Check we don't get metadata for things that don't exist."""
+    with pytest.raises(FileNotFoundError):
+        df_from_metadata_yaml_files("DIRECTORY_DOESNT_EXIST", dict())
+
+    with tempfile.TemporaryDirectory() as empty_existing_directory:
+        testme = df_from_metadata_yaml_files(empty_existing_directory, dict())
+    assert testme.empty, "There shouldn't be any data in the df."

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,9 @@
 [tox]
-envlist = py{38,39,310,311}
+envlist = py{39,310,311}
 isolated_build = True
 
 [gh-actions]
 python =
-    3.8: py38
     3.9: py39
     3.10: py310
     3.11: py311


### PR DESCRIPTION
More noise from me.

Here is a (very) basic unit test for `wazp.utils.df_from_metadata_yaml_files` (relates to #27).

Now [tox py38 (pytest@3.8) fails](https://github.com/SainsburyWellcomeCentre/WAZP/actions/runs/4182565018/jobs/7245871921#step:2:500) because of the `TypeError` due to [this deprecation](https://docs.python.org/3/library/typing.html?highlight=subscripting#typing.List), or rather: due to the extension of `builtin` which happens 3.8 → 3.9. (We're using the 3.9+ standard 👍.) 


~~I'm not entirely sure why we only notice this now.~~ ... oh: because we've probably never tried running WAZP in python3.8.