### PR TITLE
Integration testing mechanics.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dev = [
 	"pytest",
 	"pytest-cov",
 	"coverage",
+  "dash[testing]",
 	"tox",
 	"black",
   "isort",

--- a/tests/test_integration/conftest.py
+++ b/tests/test_integration/conftest.py
@@ -1,0 +1,8 @@
+from selenium.webdriver.chrome.options import Options
+
+
+def pytest_setup_options():
+    options = Options()
+    options.add_argument("--headless")
+    options.add_argument("--disable-gpu")
+    return options

--- a/tests/test_integration/test_smoke.py
+++ b/tests/test_integration/test_smoke.py
@@ -1,0 +1,24 @@
+# 1. imports of your dash app
+import dash
+from dash import html
+
+
+# 2. give each testcase a test case ID, and pass the fixture
+# dash_duo as a function argument
+def test_001_child_with_0(dash_duo):
+    # 3. define your app inside the test function
+    app = dash.Dash(__name__)
+    app.layout = html.Div(id="nully-wrapper", children=0)
+    # 4. host the app locally in a thread, all dash server configs could be
+    # passed after the first app argument
+    dash_duo.start_server(app)
+    # 5. use wait_for_* if your target element is the result of a callback,
+    # keep in mind even the initial rendering can trigger callbacks
+    dash_duo.wait_for_text_to_equal("#nully-wrapper", "0", timeout=4)
+    # 6. use this form if its present is expected at the action point
+    assert dash_duo.find_element("#nully-wrapper").text == "0"
+    # 7. to make the checkpoint more readable, you can describe the
+    # acceptance criterion as an assert message after the comma.
+    assert dash_duo.get_logs() == [], "browser console should contain no error"
+    # 8. visual testing with percy snapshot
+    dash_duo.percy_snapshot("test_001_child_with_0-layout")


### PR DESCRIPTION
As discussed in #27, we also want "end-to-end" tests/integrations tests that _actually_ start the web app and ... do things.

I'm not sure about the doing things part yet, but I can get the mechanics of [dash's basic example](https://dash.plotly.com/testing#example---basic-test) to work.
 * Chrome browser and chromedriver [are already installed on the GH runners](https://community.plotly.com/t/dash-integration-testing-with-selenium-and-github-actions/43602). 
 * So just need "dash[testing]" as a dev dependency and everything will just work™️.
 * [Works on 🐧🍏](https://github.com/SainsburyWellcomeCentre/WAZP/actions/runs/4192315889/jobs/7267755200#step:2:253). But [doesn't work on Windows](https://github.com/SainsburyWellcomeCentre/WAZP/actions/runs/4192315889/jobs/7267755778#step:2:309) (because of course not... ).


To run locally:
* Install google chrome.
* Download the relevant [chrome driver](https://chromedriver.chromium.org/downloads) and put it into your path.
* Tell MacOS that it's safe.
* `python -m pip install "dash[testing]"`