### PR TITLE
Add video page

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dynamic = ["version"]
 
 license = {text = "BSD-3-Clause"}
 
-dependencies = ["pandas", "dash", "dash-bootstrap-components"]
+dependencies = ["pandas", "dash", "dash-bootstrap-components", "dash-player"]
 
 classifiers = [
     "Development Status :: 2 - Pre-Alpha",

--- a/wazp/app.py
+++ b/wazp/app.py
@@ -102,7 +102,7 @@ app.layout = html.Div(
 callbacks.get_home_callbacks(app)
 callbacks.get_metadata_callbacks(app)
 callbacks.get_dashboard_callbacks(app)
-
+callbacks.get_video_callbacks(app)
 
 ###############
 # Driver

--- a/wazp/callbacks.py
+++ b/wazp/callbacks.py
@@ -489,3 +489,36 @@ def get_dashboard_callbacks(app):
                 )
             ]
         return table_container_children
+
+
+def get_video_callbacks(app: dash.Dash) -> None:
+    """Return all callback functions for the video tab.
+
+
+    Parameters
+    ----------
+    app : dash.Dash
+        Dash app object for which these callbacks are defined
+
+    """
+
+    @app.callback(
+        Output("current-time-div", "children"),
+        Input("player", "currentTime"),
+    )
+    def display_currentTime(currentTime):
+        return f"Current Time: {currentTime}"
+
+    @app.callback(
+        Output("duration-div", "children"),
+        Input("player", "duration"),
+    )
+    def display_duration(duration):
+        return f"Duration: {duration}"
+
+    @app.callback(
+        Output("player", "playbackRate"),
+        Input("playback-rate-slider", "value"),
+    )
+    def set_playbackRate(value):
+        return value

--- a/wazp/pages/05_video.py
+++ b/wazp/pages/05_video.py
@@ -1,0 +1,64 @@
+import dash_player
+from dash import dcc, html, register_page
+
+register_page(__name__)
+
+layout = html.Div(
+    children=[
+        html.H1(children="Video player"),
+        html.Div(
+            [
+                html.Div(
+                    style={"width": "48%", "padding": "0px"},
+                    children=[
+                        dash_player.DashPlayer(
+                            id="player",
+                            url="https://youtu.be/t0Q2otsqC4I",
+                            controls=True,
+                            width="100%",
+                            height="250px",
+                        ),
+                        html.Div(
+                            [
+                                html.Div(
+                                    id="current-time-div",
+                                    style={"margin": "10px 0px"},
+                                ),
+                                html.Div(
+                                    id="duration-div",
+                                    style={"margin": "10px 0px"},
+                                ),
+                            ],
+                            style={
+                                "display": "flex",
+                                "flex-direction": "column",
+                            },
+                        ),
+                    ],
+                ),
+                html.Div(
+                    style={"width": "48%", "padding": "10px"},
+                    children=[
+                        html.P("Playback Rate:", style={"marginTop": "25px"}),
+                        dcc.Slider(
+                            id="playback-rate-slider",
+                            min=0,
+                            max=2,
+                            step=None,
+                            updatemode="drag",
+                            marks={
+                                i: str(i) + "x" for i in [0, 0.5, 1, 1.5, 2]
+                            },
+                            value=1,
+                        ),
+                    ],
+                ),
+            ],
+            style={
+                "display": "flex",
+                "flexDirection": "row",
+                "justifyContent": "space-between",
+            },
+        ),
+    ]
+)


### PR DESCRIPTION
I was playing around with playing videos within dash. I've raised this PR FYI @niksirbi @sfmig @samcunliffe, but I think it's a dead-end and shouldn't be merged.

I used the [dash player](https://dash.plotly.com/dash-player) package which looked very promising, but I couldn't get it to play any videos not supported by the browser itself (e.g. the zoo .avi's). 

It's possible that someone that knows more about videos than me (@sfmig?) can sort this out. @niksirbi and I talked about another solution of loading the videos with openCV (or ffmpeg etc) then passing these to a video player.