### PR TITLE
Docs are now set to deploy when a tag is pushed

### DIFF
--- a/.github/workflows/docs_build_and_deploy.yml
+++ b/.github/workflows/docs_build_and_deploy.yml
@@ -2,8 +2,8 @@ name: Build Sphinx docs and deploy to GitHub Pages
 
 # Generate the documentation on all merges to main, all pull requests, or by
 # manual workflow dispatch. The build job can be used as a CI check that the
-# docs still build successfully. The deploy job only runs when merging to main
-# and actually moves the generated html to the gh-pages branch
+# docs still build successfully. The deploy job only runs when a tag is
+# pushed and actually moves the generated html to the gh-pages branch
 # (which triggers a GitHub pages deployment).
 on:
   push:
@@ -24,7 +24,7 @@ jobs:
   deploy_sphinx_docs:
     name: Deploy Sphinx Docs
     needs: build_sphinx_docs
-    if: github.event_name == 'push' && github.ref_name == 'main'
+    if: github.event_name == 'push' && github.ref_type == 'tag'
     runs-on: ubuntu-latest
     steps:
       - uses: neuroinformatics-unit/actions/deploy_sphinx_docs@main


### PR DESCRIPTION
After releasing the project on PyPI, I realised that it is best for both deployments (PyPI and documentation website) to be triggered by the same event (i.e. pushing a release tag), so the documentation version agrees with the PyPI version