### PR TITLE
Smoke test other tabs.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ coverage.xml
 *,cover
 .hypothesis/
 .pytest_cache/
+.test_fail_screenshots
 
 # mypy
 .mypy_cache/

--- a/tests/test_integration/test_imports.py
+++ b/tests/test_integration/test_imports.py
@@ -1,0 +1,21 @@
+"""Trivial smoke tests of import functionality.
+
+Checks the package layout is OK, minimal checks that wazp.app.app is an app and
+has been constructed.  """
+import dash
+
+
+def test_import_wazp() -> None:
+    """Test that we can import wazp (verifies the __init__.py etc)."""
+    import wazp
+
+    print(dir(wazp))
+    # assert wazp.__doc__ != "", "WAZP has no help!"
+
+
+def test_valid_app() -> None:
+    """Test that wazp.app.app is the correct object."""
+    from wazp.app import app
+
+    assert isinstance(app, dash.Dash), "WAZP app is invalid."
+    assert app.callback_map != {}, "WAZP has no callbacks."

--- a/tests/test_integration/test_smoke.py
+++ b/tests/test_integration/test_smoke.py
@@ -1,5 +1,6 @@
-"""Smoke tests which start the server and check we can navigate without error."""
+"""Smoke tests which start the server and check we can navigate pages."""
 import os
+
 import pytest
 from dash.testing.composite import DashComposite
 
@@ -28,7 +29,6 @@ def test_start_server_open_page_no_errors(
     if errors:
         screenshots_dirname = ".test_fail_screenshots/smoke"
         os.makedirs(screenshots_dirname, exist_ok=True)  # mkdir -p
-        dash_duo.driver.save_screenshot(
-            f"./{screenshots_dirname}/test-{dash_duo.session_id}{page.replace('/', '-')}.png"
-        )
+        filename = f"test-{dash_duo.session_id}{page.replace('/', '-')}.png"
+        dash_duo.driver.save_screenshot(f"./{screenshots_dirname}/{filename}")
         assert False, f"There are {len(errors)} errors in the browser console!"

--- a/tests/test_integration/test_smoke.py
+++ b/tests/test_integration/test_smoke.py
@@ -1,17 +1,34 @@
+"""Smoke tests which start the server and check we can navigate without error."""
+import os
+import pytest
 from dash.testing.composite import DashComposite
 
 from wazp.app import app
 
 
-def test_start_server_no_errors(dash_duo: DashComposite) -> None:
-    """A minimal smoke test: launching the wazp webapp should startup, and
-    display the page content without error.
-
-    Parameters:
-        dash_duo: Default fixture for Dash Python integration tests.
-    """
+@pytest.mark.parametrize(
+    "page, title",
+    [
+        ("", "Home"),
+        ("/01-metadata", "Metadata"),
+        ("/02-roi", "ROI definition"),
+        ("/03-pose-estimation", "Pose estimation inference"),
+        ("/04-dashboard", "Dashboard"),
+    ],
+)
+def test_start_server_open_page_no_errors(
+    dash_duo: DashComposite, page: str, title: str
+) -> None:
     dash_duo.start_server(app)
-    dash_duo.wait_for_text_to_equal("h1", "Home", timeout=4)
-    assert (
-        dash_duo.get_logs() == []
-    ), "There are errors in the browser console!"
+    if page:
+        dash_duo.wait_for_page(dash_duo.server_url + page, timeout=4)
+    dash_duo.wait_for_text_to_equal("h1", title, timeout=4)
+
+    errors = dash_duo.get_logs()
+    if errors:
+        screenshots_dirname = ".test_fail_screenshots/smoke"
+        os.makedirs(screenshots_dirname, exist_ok=True)  # mkdir -p
+        dash_duo.driver.save_screenshot(
+            f"./{screenshots_dirname}/test-{dash_duo.session_id}{page.replace('/', '-')}.png"
+        )
+        assert False, f"There are {len(errors)} errors in the browser console!"


### PR DESCRIPTION
Now that #38 is merged, I'm reminded that I wanted to check all pages load without error.
     🥁 ...... [they don't](https://github.com/SainsburyWellcomeCentre/WAZP/actions/runs/4448487321/jobs/7811378837#step:3:634).

Not sure if this behaviour is expected/intended (in which case we shouldn't test for error-free loading). But perhaps it _should_ be possible to `startwazp` → not load anything → and just click around the (empty) tabs. What do you think?

## To run locally

* Same instructions as #36 (need `chromedriver` in your `PATH`).
* Screenshots of the pages where there were errors in loading are saved in `.test_fail_screenshots`.
    * They look OK to me, so tentatively: do we just silence these loading errors?