### PR TITLE
Restructure df columns

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
       hooks:
           - id: black
     - repo: https://github.com/pre-commit/mirrors-mypy
-      rev: v0.990
+      rev: v1.1.1
       hooks:
           - id: mypy
             additional_dependencies:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
       hooks:
           - id: black
     - repo: https://github.com/pre-commit/mirrors-mypy
-      rev: v1.1.1
+      rev: v0.990
       hooks:
           - id: mypy
             additional_dependencies:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,5 +132,6 @@ module = [
   "matplotlib.*",
   "plotly.*",
   "cv2.*",
+  "shapely.*",
 ]
 ignore_missing_imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,8 @@ dependencies = [
   "dash",
   "dash-bootstrap-components",
   "opencv-python",
-  "PyYAML"
+  "PyYAML",
+  "shapely",
 ]
 
 classifiers = [

--- a/sample_project/input_config.yaml
+++ b/sample_project/input_config.yaml
@@ -4,7 +4,7 @@ metadata_key_field_str: File
 pose_estimation_results_path: ./sample_project/pose_estimation_results
 model_str: DLC_resnet50_jwasp_femaleandmaleSep12shuffle1_1000000
 dashboard_export_data_path: ./sample_project/output
-roi_names:
+ROI_tags:
   - enclosure
   - left_box
   - top_box

--- a/sample_project/input_config.yaml
+++ b/sample_project/input_config.yaml
@@ -17,3 +17,4 @@ event_tags:
   - box_1_closed
   - experiment_end
 use_ROIs_order_as_hierarchy: False
+buffer_around_ROIs_boundaries: 1e-09

--- a/sample_project/input_config.yaml
+++ b/sample_project/input_config.yaml
@@ -16,3 +16,4 @@ event_tags:
   - box_1_open
   - box_1_closed
   - experiment_end
+use_ROIs_order_as_hierarchy: False

--- a/sample_project/input_config.yaml
+++ b/sample_project/input_config.yaml
@@ -2,7 +2,7 @@ videos_dir_path: ./sample_project/videos
 metadata_fields_file_path: ./sample_project/metadata_fields.yaml
 metadata_key_field_str: File
 pose_estimation_results_path: ./sample_project/pose_estimation_results
-pose_estimation_model_str: DLC_resnet50_jwasp_femaleandmaleSep12shuffle1_1000000
+model_str: DLC_resnet50_jwasp_femaleandmaleSep12shuffle1_1000000
 dashboard_export_data_path: ./sample_project/output
 roi_names:
   - enclosure

--- a/sample_project/videos/jwaspE_nectar-open-close_control.metadata.yaml
+++ b/sample_project/videos/jwaspE_nectar-open-close_control.metadata.yaml
@@ -1,10 +1,21 @@
-Common_name: jewel_wasp
-Date_end: 5/8/22
-Date_start: 5/8/22
 File: jwaspE_nectar-open-close_control.avi
-Further_description: '-'
+Species_name: Ampulex_compressa
+Common_name: jewel_wasp
+Subject: E_male
+Treatment: nectar-open-close_control
+Treatment_description: Reference 'nectar-open-close.pdf' on ceph (in \zoo\raw\LondonZoo\Experiment-protocols\Jewel-wasp_Ampulex-compressa\)
+  or Google Drive (most up-to-date version if they are different - in Experiment Protocols\jewel-wasp_Ampulex-compressa\)
+Date_start: 5/8/22
+Time_start: '11:47:53'
+Date_end: 5/8/22
+Time_end: '12:19:29'
+Time_recorded: 00:31:36
+Video_length: 00:31:36
 Hardware_description: Reference 'nectar-open-close.pdf' on ceph (in \zoo\raw\LondonZoo\Experiment-protocols\Jewel-wasp_Ampulex-compressa\)
   or Google Drive (most up-to-date version if they are different - in Experiment Protocols\jewel-wasp_Ampulex-compressa\)
+Software_description: Reference 'nectar-open-close.pdf' on ceph (in \zoo\raw\LondonZoo\Experiment-protocols\Jewel-wasp_Ampulex-compressa\)
+  or Google Drive (most up-to-date version if they are different - in Experiment Protocols\jewel-wasp_Ampulex-compressa\)
+Further_description: '-'
 ROIs:
 - drawn_on_frame: 57000
   line_color: '#2E91E5'
@@ -30,17 +41,6 @@ ROIs:
   line_color: '#222A2A'
   name: tube
   path: M722.1672180890754,559.5676484911008L718.4197091286674,572.4757349102841L718.4197091286674,584.5510415604879L720.0852686666265,586.216601098447L731.7441854323404,588.2985505208959L741.3211527756054,592.0460594813039L755.0620189637682,594.1280089037529L768.3864952674413,597.4591279796712L778.7962423796859,600.3738571710996L785.4584805315224,602.8721964780383L799.1993467196852,605.7869256694668L814.1893825613174,610.7836042833442L816.6877218682562,609.1180447453851L820.0188409441744,602.0394167090587L823.7663499045824,596.2099583262018L825.0155195580518,589.1313302898755L825.4319094425416,586.216601098447Z
-Software_description: Reference 'nectar-open-close.pdf' on ceph (in \zoo\raw\LondonZoo\Experiment-protocols\Jewel-wasp_Ampulex-compressa\)
-  or Google Drive (most up-to-date version if they are different - in Experiment Protocols\jewel-wasp_Ampulex-compressa\)
-Species_name: Ampulex_compressa
-Subject: E_male
-Time_end: '12:19:29'
-Time_recorded: 00:31:36
-Time_start: '11:47:53'
-Treatment: nectar-open-close_control
-Treatment_description: Reference 'nectar-open-close.pdf' on ceph (in \zoo\raw\LondonZoo\Experiment-protocols\Jewel-wasp_Ampulex-compressa\)
-  or Google Drive (most up-to-date version if they are different - in Experiment Protocols\jewel-wasp_Ampulex-compressa\)
-Video_length: 00:31:36
 Events:
   experiment_start: 0
   box_1_open: 25123

--- a/wazp/callbacks/dashboard.py
+++ b/wazp/callbacks/dashboard.py
@@ -511,6 +511,14 @@ def get_callbacks(app: dash.Dash) -> None:
                 )
 
                 # concatenate all dataframes
+                # NOTE: Columns outside the intersection
+                # will be filled with NaN values.
+                #
+                # Option 1: do 'df=df.fillna('')' after concat
+                # Option 2: explicitly initialise ROI_tags
+                # and event_tags columns for all video dataframes
+                # with empty strings (then ROIs and events are only assigned
+                # if defined for a video) --I'm doing this for now
                 df = pd.concat(list_df_to_export)
 
                 # ---------

--- a/wazp/callbacks/dashboard.py
+++ b/wazp/callbacks/dashboard.py
@@ -433,7 +433,7 @@ def get_callbacks(app: dash.Dash) -> None:
             color of the export message
         """
 
-        # TODO: select all rows *per page*
+        # TODO: select all rows per page?
         list_missing_pose_data_bool = [
             videos_table_data[r][POSE_DATA_STR] == FALSE_EMOJI
             for r in range(len(videos_table_data))
@@ -472,16 +472,17 @@ def get_callbacks(app: dash.Dash) -> None:
         # ---------------------------
         # If export button is clicked
         if n_clicks_export > 0:
-            # if no rows selected show warning
+            # if no rows are selected show warning
             if not list_selected_rows:
                 n_clicks_export = 0
 
                 export_message_str = "No data to export"
-                # TODO: add timestamp of message?
+                # TODO: add timestamp to the message?
                 export_message_color = "warning"
                 export_message_state = True
 
-            # if rows are selected: export combined df
+            # if rows are selected: export combined
+            # dataframe
             else:
 
                 # get list of selected videos
@@ -500,7 +501,7 @@ def get_callbacks(app: dash.Dash) -> None:
 
                 # get list of dataframes to combine
                 # - one dataframe per selected video
-                # - we add 'File', 'event_tag' and 'ROI' data to each dataframe
+                # - we add the fields 'video_file', 'event_tag' and 'ROI'
                 # - we select only the frames within the interval
                 #   set by the slider
                 list_df_to_export = utils.get_dataframes_to_combine(
@@ -513,21 +514,24 @@ def get_callbacks(app: dash.Dash) -> None:
                 df = pd.concat(list_df_to_export)
 
                 # ---------
-                # Save df as h5
-                # get output path
+                # Export dataframe as h5
+                # TODO: provide an option to export as h5 or csv?
+
+                # Get path to output directory
                 # if not specified in config, use dir where
-                # 'start_wazp_server.sh' is at
+                # server was launched from
                 output_path = pl.Path(
                     app_storage["config"].get(
                         "dashboard_export_data_path", "."
                     )
                 )
 
-                # if output dir does not exist, create it
+                # If output directory does not exist,
+                # create it
                 if not output_path.is_dir():
                     os.mkdir(output_path)
 
-                # save combined df as h5 file
+                # Save combined dataframe as h5 file
                 h5_file_path = output_path / pl.Path(
                     "df_export_"
                     + datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
@@ -540,7 +544,7 @@ def get_callbacks(app: dash.Dash) -> None:
                 )
 
                 # ---------
-                # reset triggers and states
+                # Reset triggers and states
                 list_selected_rows = []
                 n_clicks_export = 0
                 export_message_str = (

--- a/wazp/callbacks/dashboard.py
+++ b/wazp/callbacks/dashboard.py
@@ -1,5 +1,4 @@
 import datetime
-import os
 import pathlib as pl
 import re
 
@@ -433,7 +432,6 @@ def get_callbacks(app: dash.Dash) -> None:
             color of the export message
         """
 
-        # TODO: select all rows per page?
         list_missing_pose_data_bool = [
             videos_table_data[r][POSE_DATA_STR] == FALSE_EMOJI
             for r in range(len(videos_table_data))
@@ -511,14 +509,10 @@ def get_callbacks(app: dash.Dash) -> None:
                 )
 
                 # concatenate all dataframes
-                # NOTE: Columns outside the intersection
-                # will be filled with NaN values.
-                #
-                # Option 1: do 'df=df.fillna('')' after concat
-                # Option 2: explicitly initialise ROI_tags
+                # NOTE: we explicitly initialise ROI_tags
                 # and event_tags columns for all video dataframes
                 # with empty strings (then ROIs and events are only assigned
-                # if defined for a video) --I'm doing this for now
+                # if defined for a video)
                 df = pd.concat(list_df_to_export)
 
                 # ---------
@@ -536,8 +530,7 @@ def get_callbacks(app: dash.Dash) -> None:
 
                 # If output directory does not exist,
                 # create it
-                if not output_path.is_dir():
-                    os.mkdir(output_path)
+                output_path.mkdir(parents=True, exist_ok=True)
 
                 # Save combined dataframe as h5 file
                 h5_file_path = output_path / pl.Path(

--- a/wazp/callbacks/roi.py
+++ b/wazp/callbacks/roi.py
@@ -109,7 +109,7 @@ def get_callbacks(app: dash.Dash) -> None:
         if "config" in app_storage.keys():
             # Get ROI names from stored config
             config = app_storage["config"]
-            roi_names = config["roi_names"]
+            roi_names = config["ROI_tags"]
             options = [{"label": r, "value": r} for r in roi_names]
             value = roi_names[0]
 

--- a/wazp/utils.py
+++ b/wazp/utils.py
@@ -341,17 +341,19 @@ def get_dataframes_to_combine(
         # - only set ROI if not previously defined
         # TODO: Is there a better approach?
         # TODO: should we allow for a custom hierarchy?
-        df = add_ROIs_to_video_dataframe(
-            df, metadata, ROIs_as_polygons, app_storage
-        )
+        if "ROIs" in metadata:
+            df = add_ROIs_to_video_dataframe(
+                df, metadata, ROIs_as_polygons, app_storage
+            )
 
-        # Add Event tags
+        # Add Event tags if defined
         # - if no event is defined for that frame: empty str
         # - if an event is defined for that frame: event_tag
-        df["event_tag"] = ""
-        for event_str in metadata["Events"].keys():
-            event_frame = metadata["Events"][event_str]
-            df.loc[df.frame == event_frame, "event_tag"] = event_str
+        if "Events" in metadata:
+            df["event_tag"] = ""
+            for event_str in metadata["Events"].keys():
+                event_frame = metadata["Events"][event_str]
+                df.loc[df.frame == event_frame, "event_tag"] = event_str
 
         # Append to list
         list_df_to_export.append(df)

--- a/wazp/utils.py
+++ b/wazp/utils.py
@@ -99,7 +99,7 @@ def set_edited_row_checkbox_to_true(
     # ignore static type checking here,
     # see https://github.com/pandas-dev/pandas-stubs/issues/256
     df_diff = df.merge(df_previous, how="outer", indicator=True).loc[
-        lambda x: x["_merge"] == "left_only"  # type: ignore
+        lambda x: x["_merge"] == "left_only"
     ]
 
     # Update the set of selected rows
@@ -200,13 +200,13 @@ def read_and_restructure_DLC_dataframe(
     if is_multianimal:
         columns_to_stack.append("individual")
     df = df.stack(level=columns_to_stack)  # type: ignore
+    # Not sure why mypy complains, list of labels is allowed
+    # https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.stack.html
+    # ignoring for now
 
     # reset index to remove 'frame','scorer' and 'bodyparts'
     # if multianimal, also remove 'individuals'
-    index_levels_to_remove = ["frame", "scorer", "bodyparts"]
-    if is_multianimal:
-        index_levels_to_remove.append("individual")
-    df = df.reset_index(level=index_levels_to_remove)  # type: ignore
+    df = df.reset_index()  # removes all levels in index by default
 
     # reset name of set of columns and indices
     # (to remove columns name = 'coords')

--- a/wazp/utils.py
+++ b/wazp/utils.py
@@ -98,8 +98,6 @@ def set_edited_row_checkbox_to_true(
     df = pd.DataFrame(data=data)
     df_previous = pd.DataFrame(data_previous)
 
-    # ignore static type checking here,
-    # see https://github.com/pandas-dev/pandas-stubs/issues/256
     df_diff = df.merge(df_previous, how="outer", indicator=True).loc[
         lambda x: x["_merge"] == "left_only"
     ]
@@ -158,7 +156,6 @@ def read_and_restructure_DLC_dataframe(
       (e.g. 'DLC_resnet50_jwasp_femaleandmaleSep12shuffle1_1000000').
     - bodyparts: the keypoints tracked in the animal (e.g., head, thorax)
     - coords: x, y, likelihood
-    # TODO: is this different in multianimal? (maybe an extra ID column?)
 
     We reshape the dataframe to have a single level along the columns,
     and the following columns:
@@ -306,14 +303,6 @@ def get_dataframes_to_combine(
             metadata["Events"][x] for x in slider_start_end_labels
         ]
 
-        # Extract ROI paths for this video if defined
-        # TODO: should I do case insensitive?
-        # if "rois" in [ky.lower() for ky in metadata.keys()]:
-        if "ROIs" in metadata:
-            ROIs_as_polygons = {
-                el["name"]: svg_path_to_polygon(el["path"])
-                for el in metadata["ROIs"]
-            }
         # -----------------------------
 
         # Read h5 file and reorganise columns
@@ -324,8 +313,8 @@ def get_dataframes_to_combine(
         # Extract subset of rows based on events slider
         # (frame numbers from slider, both inclusive)
         df = df.loc[
-            (df.frame >= frame_start_end[0])
-            & (df.frame <= frame_start_end[1]),
+            (df["frame"] >= frame_start_end[0])
+            & (df["frame"] <= frame_start_end[1]),
             :,
         ]
 
@@ -358,7 +347,7 @@ def get_dataframes_to_combine(
         if "Events" in metadata:
             for event_str in metadata["Events"].keys():
                 event_frame = metadata["Events"][event_str]
-                df.loc[df.frame == event_frame, "event_tag"] = event_str
+                df.loc[df["frame"] == event_frame, "event_tag"] = event_str
 
         # Append to list
         list_df_to_export.append(df)

--- a/wazp/utils.py
+++ b/wazp/utils.py
@@ -402,14 +402,14 @@ def add_ROIs_to_video_dataframe(
     Parameters
     ----------
     df : pd.Dataframe
-        pandas dataframe holding the pose estimation results
+        pandas dataframe with the pose estimation results
         for one video. It is a single-level dataframe, restructured
         from the DeepLabCut output.
     metadata : dict
-        dictionary holding the metadata for the current video.
+        dictionary with the metadata for the current video.
     ROIs_as_polygons : dict
-        dictionary holding pairs of ROI tags and their corresponding
-        shapely polygons for the current video.
+        dictionary for the current video with ROI tags as keys,
+        and their corresponding shapely polygons as values.
     app_storage : dict
         data held in temporary memory storage,
         accessible to all tabs in the app
@@ -417,7 +417,9 @@ def add_ROIs_to_video_dataframe(
     Returns
     -------
     df : pd.Dataframe
-        _description_
+        pandas dataframe with the pose estimation results
+        for one video, and the ROI per bodypart per frame
+        assigned.
     """
 
     # Initialize ROI column with empty strings

--- a/wazp/utils.py
+++ b/wazp/utils.py
@@ -370,6 +370,8 @@ def svg_path_to_polygon(svg_path: str) -> Polygon:
     and marks the end of the string with 'Z' (end of path)
     (see [1]).
 
+    Based on original function by @niksirbi
+
     References
     ----------
     [1] "SVG Path",

--- a/wazp/utils.py
+++ b/wazp/utils.py
@@ -461,8 +461,17 @@ def add_ROIs_to_video_dataframe(
             # (applies transform in place)
             shapely.prepare(ROI_poly)
 
-            # select rows with x,y coordinates in ROI
-            # TODO: add buffer?
+            # Consider buffer around boundaries if required
+            # TODO: remove this buffer option? inspired by this SO answer
+            # https://stackoverflow.com/a/59033011
+            if "buffer_around_ROIs_boundaries" in app_storage["config"]:
+                ROI_poly = ROI_poly.buffer(
+                    float(
+                        app_storage["config"]["buffer_around_ROIs_boundaries"]
+                    )
+                )
+
+            # select rows with x,y coordinates inside ROI (including boundary)
             slc_rows_in_ROI = shapely.intersects_xy(
                 ROI_poly, [(x, y) for (x, y) in zip(df.x, df.y)]
             )


### PR DESCRIPTION
Restructures the dataframe imported from DLC, to make a dataframe with a single level. Adds ROI per frame and bodypart (and individual if the data is from a multianimal project), and event tags per frame.

Columns in exported dataframe:

| 'model_str' | 'video_file' | 'individual'* | 'frame' | 'bodypart' | 'x' | 'y' | 'likelihood' | 'ROI_tag' | 'event_tag' |
| --- |--- |--- |--- |--- |--- |--- |--- |--- |--- |

*if multi-animal

### Features
- the user can define the hierarchy of ROIs to handle cases in which a point is inside two (or more) ROIs. If not defined, the ROI with smallest area prevails.
- the user can define a buffer around the ROI boundaries if desired. This was inspired by [this SO post](https://stackoverflow.com/a/59033011), but not sure if it would be very used.
- the event_tag column holds an empty string for the frames with no tag defined, and the event_tag string if the frame was labelled.
- a point is inside an ROI if its x,y coordinates for one frame are inside or at the boundary of the ROI.

### mypy errors
I had some errors with mypy and pandas, I fixed some but others I couldn't figure out why... I marked those with `# type: ignore` for now. I didn't have errors when running mypy directly, but they did show up with the precommit hooks

This PR addresses issues:
- #17
- #40

