### PR TITLE
Windows instructions for running the chromedriver tests.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,6 +115,16 @@ pytest # in the root of the repository
 
 </details>
 
+<details>
+<summary>Windows</summary>
+
+For Windows, simply download ``chromedriver_win32.zip`` file, extract the executable, and either place it in the directory where you want to run ``pytest`` or add it to your `env:Path` (tested in Windows 10 with PowerShell):
+
+```pwsh
+$env:Path += ";C:\path\to\chromedriver\"
+```
+
+</details>
 
 It's a good idea to test locally before pushing. Pytest will run all tests and also report test coverage.
 


### PR DESCRIPTION
Installing everything for dev on Windows was surprisingly easy:  no special modification of the general instructions was needed other than adding `chromedriver.exe` to the `$env:Path`.