### PR TITLE
Intercept KeyError on navigation straight to the metadata tab without adding a config.

### DIFF
--- a/tests/test_integration/test_common_layout.py
+++ b/tests/test_integration/test_common_layout.py
@@ -71,7 +71,7 @@ unloaded_config_xfail = pytest.mark.xfail(
         for fx, mark in [
             ("home_page_name_and_title", []),
             ("metadata_page_name_and_title", []),
-            ("roi_page_name_and_title", unloaded_config_xfail),
+            ("roi_page_name_and_title", []),
             ("pose_estimation_page_name_and_title", []),
             ("dashboard_page_name_and_title", unloaded_config_xfail),
         ]

--- a/tests/test_integration/test_common_layout.py
+++ b/tests/test_integration/test_common_layout.py
@@ -70,7 +70,7 @@ unloaded_config_xfail = pytest.mark.xfail(
         pytest.param(fx, marks=mark)
         for fx, mark in [
             ("home_page_name_and_title", []),
-            ("metadata_page_name_and_title", unloaded_config_xfail),
+            ("metadata_page_name_and_title", []),
             ("roi_page_name_and_title", unloaded_config_xfail),
             ("pose_estimation_page_name_and_title", []),
             ("dashboard_page_name_and_title", unloaded_config_xfail),

--- a/tests/test_integration/test_common_layout.py
+++ b/tests/test_integration/test_common_layout.py
@@ -34,16 +34,12 @@ def test_components_created(
 
     # wait for sidebar to be rendered
     try:
-        dash_duo.wait_for_text_to_equal(
-            "#sidebar h2", "WAZP 🐝", timeout=timeout
-        )
+        dash_duo.wait_for_text_to_equal("#sidebar h2", "WAZP 🐝", timeout=timeout)
     except selenium.common.exceptions.TimeoutException:
         pytest.fail("Sidebar component not generated")
 
     # check there are no errors in browser console
-    assert (
-        dash_duo.get_logs() == []
-    ), f"There are {len(dash_duo.get_logs())} errors"
+    assert dash_duo.get_logs() == [], f"There are {len(dash_duo.get_logs())} errors"
     " in the browser console!"
 
 
@@ -133,6 +129,4 @@ def test_sidebar_links(
     # ...
 
     # NOTE: this is expected to fail for a few pages (hence the marked xfails)
-    assert (
-        dash_duo.get_logs() == []
-    ), "There are errors in the browser console!"
+    assert dash_duo.get_logs() == [], "There are errors in the browser console!"

--- a/wazp/app.py
+++ b/wazp/app.py
@@ -86,7 +86,7 @@ content = html.Div(
 storage = dcc.Store(
     id="session-storage",
     storage_type="session",
-    data=tuple(),
+    data={},
 )
 
 ###############

--- a/wazp/callbacks/_common.py
+++ b/wazp/callbacks/_common.py
@@ -1,0 +1,8 @@
+from dash import html
+
+NO_CONFIG_MESSAGE = html.Div(
+    children="No configuration loaded. Please add a "
+    "configuration file from the 'Home' page."
+)
+
+VIDEO_TYPES = [".avi", ".mp4"]

--- a/wazp/callbacks/metadata.py
+++ b/wazp/callbacks/metadata.py
@@ -251,6 +251,12 @@ def get_callbacks(app: dash.Dash) -> None:
             to the ROI tab, for example).
         """
 
+        # Windows sometimes gives a the State data as an empty _list_ (!) when
+        # there is nothing present, so guard against that here.
+        if isinstance(app_storage, list) and app_storage == []:
+            warnings.warn("Seems there is no data in app storage")
+            app_storage = {}
+
         try:
             app_storage["config"]
         except KeyError:

--- a/wazp/callbacks/metadata.py
+++ b/wazp/callbacks/metadata.py
@@ -2,6 +2,7 @@ import base64
 import io
 import pathlib as pl
 import re
+import warnings
 
 import dash
 import dash_bootstrap_components as dbc
@@ -219,7 +220,7 @@ def get_callbacks(app: dash.Dash) -> None:
     )
     def create_metadata_table_and_buttons(
         metadata_output_children: list, app_storage: dict
-    ) -> html.Div:
+    ) -> html.Div | None:
         """Generate html component with a table holding the
         metadata per video and with auxiliary buttons for
         common table manipulations.
@@ -241,7 +242,24 @@ def get_callbacks(app: dash.Dash) -> None:
         html.Div
             html component holding the metadata dash_table and
             the auxiliary buttons for common table manipulations
+
+        Warns
+        -----
+        UserWarning
+            If no configuration is found (from navigating directly
+            to the ROI tab, for example).
         """
+
+        try:
+            app_storage["config"]
+        except KeyError:
+            # we've likely navigated to the metadata page without an input
+            # config yaml file... not necessarily an error
+            warnings.warn("Configuration not yet loaded.")
+            return html.Div(
+                children="No configuration loaded. Please add a "
+                "configuration file from the 'Home' page."
+            )
 
         if not metadata_output_children:
             metadata_table = create_metadata_table_component_from_df(
@@ -373,6 +391,7 @@ def get_callbacks(app: dash.Dash) -> None:
                     generate_yaml_tooltip,
                 ]
             )
+        return None
 
     @app.callback(
         Output("metadata-table", "data"),

--- a/wazp/callbacks/metadata.py
+++ b/wazp/callbacks/metadata.py
@@ -12,9 +12,7 @@ import yaml
 from dash import Input, Output, State, dash_table, dcc, html
 
 from wazp import utils
-
-# TODO: other video extensions? have this in project config file instead?
-VIDEO_TYPES = [".avi", ".mp4"]
+from wazp.callbacks._common import NO_CONFIG_MESSAGE, VIDEO_TYPES
 
 
 ##########################
@@ -251,22 +249,11 @@ def get_callbacks(app: dash.Dash) -> None:
             to the ROI tab, for example).
         """
 
-        # Windows sometimes gives a the State data as an empty _list_ (!) when
-        # there is nothing present, so guard against that here.
-        if isinstance(app_storage, list) and app_storage == []:
-            warnings.warn("Seems there is no data in app storage")
-            app_storage = {}
-
-        try:
-            app_storage["config"]
-        except KeyError:
+        if not app_storage:
             # we've likely navigated to the metadata page without an input
             # config yaml file... not necessarily an error
             warnings.warn("Configuration not yet loaded.")
-            return html.Div(
-                children="No configuration loaded. Please add a "
-                "configuration file from the 'Home' page."
-            )
+            return NO_CONFIG_MESSAGE
 
         if not metadata_output_children:
             metadata_table = create_metadata_table_component_from_df(

--- a/wazp/callbacks/metadata.py
+++ b/wazp/callbacks/metadata.py
@@ -3,6 +3,7 @@ import io
 import pathlib as pl
 import re
 import warnings
+from typing import Union
 
 import dash
 import dash_bootstrap_components as dbc
@@ -220,7 +221,7 @@ def get_callbacks(app: dash.Dash) -> None:
     )
     def create_metadata_table_and_buttons(
         metadata_output_children: list, app_storage: dict
-    ) -> html.Div | None:
+    ) -> Union[html.Div, None]:
         """Generate html component with a table holding the
         metadata per video and with auxiliary buttons for
         common table manipulations.

--- a/wazp/callbacks/roi.py
+++ b/wazp/callbacks/roi.py
@@ -13,9 +13,8 @@ from dash import Input, Output, State
 from PIL import Image
 
 from wazp import utils
+from wazp.callbacks._common import VIDEO_TYPES
 
-# TODO: other video extensions? have this in project config file instead?
-VIDEO_TYPES = [".avi", ".mp4"]
 ROI_CMAP = px.colors.qualitative.Dark24
 
 
@@ -536,6 +535,8 @@ def get_callbacks(app: dash.Dash) -> None:
         int
             Maximum frame index (num_frames - 1)
         """
+        if not roi_color_mapping:
+            return dash.no_update, "", "light", False
 
         # If a negative frame index is passed, it means that the video
         # could not be read correctly. So don't update the frame,


### PR DESCRIPTION
Solves the first part of 
* #83. 

If no config is found, then show a message explaining that there's no config loaded and return. Also, the function didn't explicitly return if ``metadata_output_children`` so I also fix that.

~~The eagle-eyed amongst you might notice that this is testless 🤢 `#WhatAboutAllOfYouTDDEvangelismSam`?. But this will be covered by a tweak to one of the files introduced in #82 (which _should_ probably go in first but not mandatory).~~

_Edit:_ **Now** ready for review (sorry for the noise). Tested and looking good. I also fixed an error on the ROI page (which now also loads without error if no config).

The dashboard is still an `XFAIL` and is a bit more complicated so should go in a separate PR.