### PR TITLE
Printing chrome and chromedriver versions.

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -43,6 +43,13 @@ jobs:
         run: |
           echo "C:\Program Files\Google\Chrome\Application" >> $GITHUB_PATH
 
+      - name: Print chrome version on Windows
+        if: matrix.os == 'windows-latest'
+        shell: pwsh
+        run: |
+          (Get-Item "C:\Program Files\Google\Chrome\Application\chrome.exe").VersionInfo
+          chromedriver --version
+
       # Run tests
       - uses: neuroinformatics-unit/actions/test@v2.0.0
         with:

--- a/tests/test_integration/conftest.py
+++ b/tests/test_integration/conftest.py
@@ -88,4 +88,4 @@ def timeout() -> float:
     timeout : float
         maximum time to wait in seconds
     """
-    return 4
+    return 8


### PR DESCRIPTION
This may help diagnose #65. There are some claims on SO that it can be caused by version incompatibility between the two. I'm sceptical given [Niko's error was in the first chromedriver test](https://github.com/SainsburyWellcomeCentre/WAZP/actions/runs/5267489847/jobs/9522834408) (and subsequent tests also using chrome ran just dandy). But I'd say worth having this in for the next time #65 appears.


----
Also, I asked around in ARC today about #65:

> Yeah I've ended up putting in silly sleep conditions at points - so hacky but did get the job done

[A wise anonymous source]

So maybe 8 seconds is magically long enough to wait?