### PR TITLE
added check-manifest pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,3 +31,8 @@ repos:
                 - types-PyYaML
                 - pandas-stubs
                 - types-Pillow
+    - repo: https://github.com/mgedmin/check-manifest
+      rev: "0.49"
+      hooks:
+          - id: check-manifest
+            additional_dependencies: [setuptools-scm]


### PR DESCRIPTION
`check-manifest` always trips me up. It's part of our actions workflow, but not of `pre-commit`. This results in me discovering annoying manifest problems only after I push.
I think it's worth adding `check-manifest` to the `pre-commit` hooks, so we catch the problems at their root.
They only downside I can think of is that the pre-commit check will be *slightly* slower.