### PR TITLE
Support 3.11.

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         # Run all supported Python versions on linux (plus one development unsupported)
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
         os: [ubuntu-latest]
         # Include one windows and macos run
         include:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Operating System :: OS Independent",
     "License :: OSI Approved :: BSD License",
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{39,310,311}
+envlist = py{39,310,311,312}
 isolated_build = True
 
 [gh-actions]
@@ -7,6 +7,7 @@ python =
     3.9: py39
     3.10: py310
     3.11: py311
+    3.12: py312
 
 [testenv]
 extras =


### PR DESCRIPTION
Add "official" support for 3.11 in pyproject.toml

* Solves #54 

At the same time, add 3.12 to CI so we can test against that too. (I'm doing a winter-clearout of my issues: #54 looked more straightforward to fix directly than continue the ticket management.)