### PR TITLE
Make `mypy` happy again.

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -12,13 +12,13 @@ jobs:
   linting:
     runs-on: ubuntu-latest
     steps:
-      - uses: neuroinformatics-unit/actions/lint@v2.0.0
+      - uses: neuroinformatics-unit/actions/lint@v2
 
   manifest:
     name: Check Manifest
     runs-on: ubuntu-latest
     steps:
-      - uses: neuroinformatics-unit/actions/check_manifest@v2.0.0
+      - uses: neuroinformatics-unit/actions/check_manifest@v2
 
   test:
     needs: [linting, manifest]

--- a/scripts/generate_sample_projects/pose_utils.py
+++ b/scripts/generate_sample_projects/pose_utils.py
@@ -33,7 +33,7 @@ def load_poses_from_dlc(file_path: Path) -> Optional[pd.DataFrame]:
     return df
 
 
-def save_poses_to_dlc(df: pd.DataFrame, file_path: Path):
+def save_poses_to_dlc(df: pd.DataFrame | pd.Series, file_path: Path):
     """Save pose estimation results to a DeepLabCut (DLC) .h5 file.
     Also saves the poses to a .csv file with the same name.
 

--- a/wazp/callbacks/metadata.py
+++ b/wazp/callbacks/metadata.py
@@ -662,8 +662,8 @@ def get_callbacks(app: dash.Dash) -> None:
             # convert all fields in dataframe to strings
             # (otherwise datetime fields are not encoded correctly in the YAML)
             df = df.applymap(str)  # type: ignore[operator]
-            # TODO: remove ignore comment 👆 if we update the linter job to 3.11
-            #       with newer pandas-stubs
+            # TODO: remove mypy ignore comment 👆 if we update the linter job to
+            #       3.11 with newer pandas-stubs version
 
             # check if columns in spreadsheet match metadata file:
             # if not, add missing columns

--- a/wazp/callbacks/metadata.py
+++ b/wazp/callbacks/metadata.py
@@ -661,7 +661,9 @@ def get_callbacks(app: dash.Dash) -> None:
 
             # convert all fields in dataframe to strings
             # (otherwise datetime fields are not encoded correctly in the YAML)
-            df = df.applymap(str)
+            df = df.applymap(str)  # type: ignore[operator]
+            # TODO: remove ignore comment 👆 if we update the linter job to 3.11
+            #       with newer pandas-stubs
 
             # check if columns in spreadsheet match metadata file:
             # if not, add missing columns


### PR DESCRIPTION
Something typed as a `pandas.DataFrame` is actually being passed a `pandas.Series[Any]`.

How did we not notice this... 🤷.